### PR TITLE
Add environment submission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,79 @@
+name: CD
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-frontend:
+    name: Build and Push Frontend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta-frontend
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend
+        tags: |
+          type=sha,format=long
+          type=ref,event=branch
+    
+    - name: Build and push frontend Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./frontend
+        push: true
+        tags: ${{ steps.meta-frontend.outputs.tags }}
+        labels: ${{ steps.meta-frontend.outputs.labels }}
+
+  build-and-push-backend:
+    name: Build and Push Backend
+    runs-on: ubuntu-latest
+    needs: build-and-push-frontend
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta-backend
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/backend
+        tags: |
+          type=sha,format=long
+          type=ref,event=branch
+    
+    - name: Build and push backend Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./backend
+        push: true
+        tags: ${{ steps.meta-backend.outputs.tags }}
+        labels: ${{ steps.meta-backend.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '24.x'
         cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
     
     - name: Install dependencies
       working-directory: ./frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.24'
     
     - name: Cache Go modules
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  frontend-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      working-directory: ./frontend
+      run: npm ci
+    
+    - name: Run tests with coverage
+      working-directory: ./frontend
+      run: npm test -- --coverage --watchAll=false
+    
+    - name: Check test coverage
+      working-directory: ./frontend
+      run: |
+        COVERAGE=$(grep -oP 'All files[^|]*\|\s*\K[^|]*(?=\s*\|)' coverage/coverage-summary.json | grep -oP '\d+' | head -1)
+        if [ "$COVERAGE" -lt 80 ]; then
+          echo "Coverage is below 80%"
+          exit 1
+        fi
+
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+    
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    
+    - name: Run tests with coverage
+      working-directory: ./backend
+      run: |
+        go test -v -coverprofile=coverage.out ./...
+        go tool cover -func=coverage.out
+        
+        # Check coverage is at least 80%
+        COVERAGE=$(go tool cover -func=coverage.out | grep total: | grep -oP '\d+\.\d+')
+        if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+          echo "Coverage is below 80%"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     
-    - name: Run tests with coverage
+    - name: Download Go modules
       working-directory: ./backend
-      run: |
-        go test -v -coverprofile=coverage.out ./...
-        go tool cover -func=coverage.out
-        
-        # Check coverage is at least 80%
-        COVERAGE=$(go tool cover -func=coverage.out | grep total: | grep -oP '\d+\.\d+')
-        if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-          echo "Coverage is below 80%"
-          exit 1
-        fi
+      run: go mod download
+      
+    - name: Run backend tests and check coverage
+      run: make test-backend

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 coverage.out
 coverage_filtered.out
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.log
+coverage.out
+coverage_filtered.out

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,33 @@ FRONTEND_PID := frontend.pid
 # Frontend (Next.js)
 FRONTEND_DIR := frontend
 
-.PHONY: all dev-backend run-backend build-backend clean-backend lint-backend \
-        dev-frontend build-frontend lint-frontend format-frontend \
-        start stop logs all lint deps test-backend test-frontend
+.PHONY: test-backend dev-backend run-backend build-backend clean-backend lint-backend \
+        test-frontend dev-frontend build-frontend lint-frontend format-frontend \
+        start stop logs all lint deps
 
 ## ---------- GLOBAL ----------
 ## Start everything (backend and frontend in the background)
 all: deps start
+
+## Show help
+help:
+	@echo "Drifter Project"
+	@echo
+	@echo "Targets:"
+	@echo "  all          - Build and run everything"
+	@echo "  deps         - Install dependencies"
+	@echo "  dev-backend  - Run backend in development mode"
+	@echo "  run-backend  - Run backend in production mode"
+	@echo "  build-backend - Build backend binary"
+	@echo "  clean-backend - Clean backend build artifacts"
+	@echo "  lint-backend  - Lint backend code"
+	@echo "  dev-frontend  - Run frontend in development mode"
+	@echo "  build-frontend - Build frontend"
+	@echo "  lint-frontend  - Lint frontend code"
+	@echo "  format-frontend - Format frontend code"
+	@echo "  start        - Start backend and frontend in the background"
+	@echo "  stop         - Stop all running services"
+	@echo "  logs         - View logs from running services"
 
 ## Install dependencies
 deps:
@@ -95,7 +115,7 @@ test-backend:
 	cd $(BACKEND_DIR) && grep -v internal/world coverage.out > coverage_filtered.out
 	@coverage=$$(cd $(BACKEND_DIR) && go tool cover -func=coverage_filtered.out | tail -1 | awk '{print substr($$3,1,length($$3)-1)}'); \
 	echo "Backend coverage: $$coverage%"; \
-	awk -v cov=$$coverage 'BEGIN { if (cov < 80) { print "Coverage below 80%"; exit 1 } }'
+	awk -v cov=$coverage 'BEGIN { if (cov < 80) { print "Coverage below 80%"; exit 1 } }'
 
 ## ---------- FRONTEND ----------
 ## Run frontend in development mode (blocks)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -o main ./cmd/
+
+# Final stage
+FROM alpine:latest
+
+WORKDIR /app
+
+# Install certificates for HTTPS
+RUN apk --no-cache add ca-certificates
+
+# Copy the binary from builder
+COPY --from=builder /app/main .
+COPY --from=builder /app/configs ./configs
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Command to run the executable
+CMD ["./main"]

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,7 +3,8 @@ module github.com/solo-seven/drifter.solo7.media
 go 1.24.4
 
 require (
-	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/gorilla/handlers v1.5.2 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/gorilla/handlers v1.5.2
+	github.com/gorilla/mux v1.8.1
 )
+
+require github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,8 +3,12 @@ module github.com/solo-seven/drifter.solo7.media
 go 1.24.4
 
 require (
-	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
+	github.com/stretchr/testify v1.10.0
 )
 
-require github.com/felixge/httpsnoop v1.0.3 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,6 +1,12 @@
-github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
-github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -13,8 +17,9 @@ func main() {
 	// Create a new router
 	router := mux.NewRouter()
 
-	// Register the health check endpoint
+	// Register endpoints
 	router.HandleFunc("/health", healthCheck).Methods("GET")
+	router.HandleFunc("/environments", saveEnvironment).Methods("POST")
 
 	// Set up CORS
 	callowedOrigins := handlers.AllowedOrigins([]string{"http://localhost:3000"})
@@ -29,4 +34,51 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func saveEnvironment(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		http.Error(w, "empty body", http.StatusBadRequest)
+		return
+	}
+
+	// Prepare log entry
+	record := map[string]json.RawMessage{}
+	ts := time.Now().UTC().Format(time.RFC3339)
+	record["timestamp"] = json.RawMessage([]byte("\"" + ts + "\""))
+	record["environment"] = body
+	line, err := json.Marshal(record)
+	if err != nil {
+		http.Error(w, "failed to marshal record", http.StatusInternalServerError)
+		return
+	}
+
+	logPath := os.Getenv("ENV_LOG_FILE")
+	if logPath == "" {
+		logPath = "logs/environments.log"
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		http.Error(w, "failed to prepare log directory", http.StatusInternalServerError)
+		return
+	}
+
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		http.Error(w, "failed to open log", http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		http.Error(w, "failed to write log", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{"status": "saved"})
 }

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHealthCheck(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+
+	healthCheck(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", rr.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("unexpected response: %v", resp)
+	}
+}
+
+func TestSaveEnvironmentSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "env.log")
+	os.Setenv("ENV_LOG_FILE", logPath)
+	defer os.Unsetenv("ENV_LOG_FILE")
+
+	body := `{"foo":"bar"}`
+	req := httptest.NewRequest(http.MethodPost, "/environments", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	saveEnvironment(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201 got %d", rr.Code)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 log line got %d", len(lines))
+	}
+	var rec map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("invalid log JSON: %v", err)
+	}
+	if !strings.Contains(string(rec["environment"]), "foo") {
+		t.Errorf("log missing environment: %s", rec["environment"])
+	}
+}
+
+func TestSaveEnvironmentEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/environments", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	saveEnvironment(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 got %d", rr.Code)
+	}
+	b, _ := io.ReadAll(rr.Body)
+	if len(b) == 0 {
+		t.Errorf("expected error body")
+	}
+}

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,14 +1,21 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -17,15 +24,133 @@ func TestHealthCheck(t *testing.T) {
 
 	healthCheck(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected status 200 got %d", rr.Code)
-	}
+	assert.Equal(t, http.StatusOK, rr.Code, "status code should be 200")
+	
 	var resp map[string]string
-	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode body: %v", err)
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err, "should decode response body without error")
+	assert.Equal(t, "ok", resp["status"], "status should be 'ok'")
+}
+
+func TestCreateHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		method        string
+		path          string
+		headers       map[string]string
+		expectedCode  int
+		expectCORS    bool
+		isPreflight   bool
+	}{
+		{
+			name:          "GET health check with CORS",
+			method:        http.MethodGet,
+			path:          "/health",
+			headers:       map[string]string{"Origin": "http://localhost:3000"},
+			expectedCode:  http.StatusOK,
+			expectCORS:    true,
+			isPreflight:   false,
+		},
+		{
+			name:    "OPTIONS preflight for health check",
+			method:  http.MethodOptions,
+			path:    "/health",
+			headers: map[string]string{
+				"Origin":                         "http://localhost:3000",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "Content-Type",
+			},
+			expectedCode:  http.StatusOK,
+			expectCORS:    true,
+			isPreflight:   true,
+		},
+		{
+			name:          "Non-existent endpoint",
+			method:        http.MethodGet,
+			path:          "/nonexistent",
+			headers:       map[string]string{"Origin": "http://localhost:3000"},
+			expectedCode:  http.StatusNotFound,
+			expectCORS:    true,
+			isPreflight:   false,
+		},
+		{
+			name:    "OPTIONS preflight for environments",
+			method:  http.MethodOptions,
+			path:    "/environments",
+			headers: map[string]string{
+				"Origin":                         "http://localhost:3000",
+				"Access-Control-Request-Method":  "POST",
+				"Access-Control-Request-Headers": "Content-Type",
+			},
+			expectedCode:  http.StatusOK,
+			expectCORS:    true,
+			isPreflight:   true,
+		},
 	}
-	if resp["status"] != "ok" {
-		t.Errorf("unexpected response: %v", resp)
+
+	handler := createHandler()
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, server.URL+tt.path, nil)
+			require.NoError(t, err, "should create request without error")
+
+			// Set request headers
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			// Make the request
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err, "should make request without error")
+			defer resp.Body.Close()
+
+			// Check status code
+			assert.Equal(t, tt.expectedCode, resp.StatusCode, 
+				"status code should match expected for %s %s", tt.method, tt.path)
+
+			// For CORS requests, check the appropriate headers
+			if tt.expectCORS && req.Header.Get("Origin") != "" {
+				// Our custom CORS middleware sets the Access-Control-Allow-Origin
+				// to the request's origin (not *) when credentials are allowed
+				expectedOrigin := req.Header.Get("Origin")
+				assert.Equal(t, expectedOrigin, resp.Header.Get("Access-Control-Allow-Origin"),
+					"Access-Control-Allow-Origin should match the request origin")
+				
+				// Check that credentials are allowed
+				assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"),
+					"Access-Control-Allow-Credentials should be true")
+
+				// For preflight requests, check for additional CORS headers
+				if tt.isPreflight {
+					// Our custom CORS middleware sets Access-Control-Allow-Methods to the requested method
+					// For the test, we'll just check that it's set to something
+					allowedMethods := resp.Header.Get("Access-Control-Allow-Methods")
+					assert.NotEmpty(t, allowedMethods, 
+						"Access-Control-Allow-Methods should not be empty for preflight")
+
+					// Our custom CORS middleware sets Access-Control-Allow-Headers to the requested headers
+					// For the test, we'll just check that it's set to something
+					allowedHeaders := resp.Header.Get("Access-Control-Allow-Headers")
+					assert.NotEmpty(t, allowedHeaders,
+						"Access-Control-Allow-Headers should not be empty for preflight")
+
+					// Check for Access-Control-Max-Age header
+					assert.Equal(t, "86400", resp.Header.Get("Access-Control-Max-Age"),
+						"Access-Control-Max-Age should be set to 86400 for preflight")
+				}
+			}
+
+			// For non-preflight requests, check the response body if it's a GET
+			if tt.method == http.MethodGet && tt.path == "/health" {
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err, "should read response body without error")
+				assert.JSONEq(t, `{"status":"ok"}`, string(body), 
+					"health check should return status ok")
+			}
+		})
 	}
 }
 
@@ -35,43 +160,326 @@ func TestSaveEnvironmentSuccess(t *testing.T) {
 	os.Setenv("ENV_LOG_FILE", logPath)
 	defer os.Unsetenv("ENV_LOG_FILE")
 
-	body := `{"foo":"bar"}`
-	req := httptest.NewRequest(http.MethodPost, "/environments", strings.NewReader(body))
-	rr := httptest.NewRecorder()
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		envKey     string
+		envValue   string
+	}{
+		{
+			name:       "simple JSON object",
+			body:       `{"foo":"bar"}`,
+			statusCode: http.StatusCreated,
+			envKey:     "foo",
+			envValue:   "bar",
+		},
+		{
+			name:       "nested JSON object",
+			body:       `{"nested":{"key":"value"}}`,
+			statusCode: http.StatusCreated,
+			envKey:     "nested",
+			envValue:   `{"key":"value"}`,
+		},
+	}
 
-	saveEnvironment(rr, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/environments", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
 
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("expected status 201 got %d", rr.Code)
-	}
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("failed to read log: %v", err)
-	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 log line got %d", len(lines))
-	}
-	var rec map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
-		t.Fatalf("invalid log JSON: %v", err)
-	}
-	if !strings.Contains(string(rec["environment"]), "foo") {
-		t.Errorf("log missing environment: %s", rec["environment"])
+			saveEnvironment(rr, req)
+
+			assert.Equal(t, tt.statusCode, rr.Code, "status code should match expected")
+
+			// Verify response body for success case
+			if tt.statusCode == http.StatusCreated {
+				var resp map[string]string
+				err := json.NewDecoder(rr.Body).Decode(&resp)
+				require.NoError(t, err, "should decode response body without error")
+				assert.Equal(t, "saved", resp["status"], "status should be 'saved'")
+
+				// Verify log file was created and contains the environment data
+				data, err := os.ReadFile(logPath)
+				require.NoError(t, err, "should read log file without error")
+
+				lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+				assert.GreaterOrEqual(t, len(lines), 1, "should have at least one log entry")
+
+				var rec map[string]json.RawMessage
+				err = json.Unmarshal([]byte(lines[len(lines)-1]), &rec)
+				require.NoError(t, err, "should unmarshal log entry without error")
+
+				// Verify timestamp exists and is valid
+				var timestamp string
+				err = json.Unmarshal(rec["timestamp"], &timestamp)
+				require.NoError(t, err, "should unmarshal timestamp without error")
+				_, err = time.Parse(time.RFC3339, timestamp)
+				assert.NoError(t, err, "timestamp should be in RFC3339 format")
+
+				// Verify environment data
+				assert.Contains(t, string(rec["environment"]), tt.envKey, "log should contain environment key")
+				assert.Contains(t, string(rec["environment"]), tt.envValue, "log should contain environment value")
+			}
+		})
 	}
 }
 
 func TestSaveEnvironmentEmpty(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/environments", http.NoBody)
-	rr := httptest.NewRecorder()
-
-	saveEnvironment(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400 got %d", rr.Code)
+	tests := []struct {
+		name       string
+		body       io.Reader
+		headers    map[string]string
+		statusCode int
+		errMsg     string
+	}{
+		{
+			name:       "empty body",
+			body:       strings.NewReader(""),
+			headers:    map[string]string{"Content-Type": "application/json"},
+			statusCode: http.StatusBadRequest,
+			errMsg:     "empty request body",
+		},
+		{
+			name:       "invalid JSON",
+			body:       strings.NewReader("{invalid"),
+			headers:    map[string]string{"Content-Type": "application/json"},
+			statusCode: http.StatusBadRequest,
+			errMsg:     "invalid JSON",
+		},
+		{
+			name:       "missing content type still works",
+			body:       strings.NewReader("{}"),
+			headers:    map[string]string{},
+			statusCode: http.StatusCreated,
+		},
 	}
-	b, _ := io.ReadAll(rr.Body)
-	if len(b) == 0 {
-		t.Errorf("expected error body")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			logPath := filepath.Join(tmpDir, "env.log")
+			os.Setenv("ENV_LOG_FILE", logPath)
+			defer os.Unsetenv("ENV_LOG_FILE")
+
+			req := httptest.NewRequest(http.MethodPost, "/environments", tt.body)
+			req.Header.Set("Content-Type", "application/json") // Set default content type
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			rr := httptest.NewRecorder()
+
+			saveEnvironment(rr, req)
+
+			assert.Equal(t, tt.statusCode, rr.Code, 
+				"status code should match expected for %s", tt.name)
+
+			if tt.errMsg != "" {
+				body, err := io.ReadAll(rr.Body)
+				require.NoError(t, err, "should read response body without error")
+				assert.Contains(t, string(body), tt.errMsg, 
+					"error message should contain expected text for %s", tt.name)
+			}
+
+			// For successful requests, verify the log file was created
+			if tt.statusCode == http.StatusCreated {
+				_, err := os.Stat(logPath)
+				assert.NoError(t, err, "log file should be created for successful request")
+			}
+		})
+	}
+}
+
+func TestSaveEnvironmentFileErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T) (string, func())
+		errMsg     string
+		statusCode int
+		expectErr  bool
+	}{
+		{
+			name: "nonexistent parent directory - should be created automatically",
+			setup: func(t *testing.T) (string, func()) {
+				tmpDir := t.TempDir()
+				logPath := filepath.Join(tmpDir, "nonexistent", "env.log")
+				os.Setenv("ENV_LOG_FILE", logPath)
+				return logPath, func() { 
+					os.Unsetenv("ENV_LOG_FILE") 
+					// Clean up the created directory
+					os.RemoveAll(filepath.Dir(logPath))
+				}
+			},
+			errMsg:     "",
+			statusCode: http.StatusCreated,
+			expectErr:  false,
+		},
+		{
+			name: "read-only file - should fail to append",
+			setup: func(t *testing.T) (string, func()) {
+				tmpDir := t.TempDir()
+				logPath := filepath.Join(tmpDir, "env.log")
+				
+				// Create and close the file first
+				f, err := os.Create(logPath)
+				require.NoError(t, err, "should create test file")
+				f.Close()
+				
+				// Set read-only permissions
+				err = os.Chmod(logPath, 0400)
+				require.NoError(t, err, "should set file permissions")
+				
+				os.Setenv("ENV_LOG_FILE", logPath)
+				return logPath, func() {
+					os.Unsetenv("ENV_LOG_FILE")
+					// Make file writable for cleanup
+					os.Chmod(logPath, 0600)
+				}
+			},
+			errMsg:     "failed to open log",
+			statusCode: http.StatusInternalServerError,
+			expectErr:  true,
+		},
+		{
+			name: "read-only parent directory - should fail to create file",
+			setup: func(t *testing.T) (string, func()) {
+				tmpDir := t.TempDir()
+				logDir := filepath.Join(tmpDir, "logs")
+				
+				// Create a read-only directory
+				err := os.Mkdir(logDir, 0400)
+				require.NoError(t, err, "should create test directory")
+				
+				logPath := filepath.Join(logDir, "env.log")
+				os.Setenv("ENV_LOG_FILE", logPath)
+				
+				return logPath, func() {
+					os.Unsetenv("ENV_LOG_FILE")
+					// Make directory writable for cleanup
+					os.Chmod(logDir, 0700)
+				}
+			},
+			errMsg:     "failed to open log",
+			statusCode: http.StatusInternalServerError,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logPath, cleanup := tt.setup(t)
+			defer cleanup()
+
+			// Get the initial state of the log file if it exists
+			initialSize := int64(0)
+			if info, err := os.Stat(logPath); err == nil {
+				initialSize = info.Size()
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/environments", strings.NewReader(`{"test":"data"}`))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			saveEnvironment(rr, req)
+
+			// Verify the response status code
+			assert.Equal(t, tt.statusCode, rr.Code, 
+				"status code should match expected for %s", tt.name)
+
+			// Verify the response body
+			body, err := io.ReadAll(rr.Body)
+			require.NoError(t, err, "should read response body without error")
+
+			if tt.expectErr {
+				// For error cases, verify the error message is in the response
+				assert.Contains(t, string(body), tt.errMsg, 
+					"error message should contain expected text for %s: got %s", tt.name, string(body))
+
+				// Verify the log file was not modified on error
+				if info, err := os.Stat(logPath); err == nil {
+					assert.Equal(t, initialSize, info.Size(), 
+						"log file should not be modified on error")
+				}
+			} else {
+				// For success cases, verify the log file was created/modified
+				info, err := os.Stat(logPath)
+				require.NoError(t, err, "log file should exist after successful write")
+				assert.Greater(t, info.Size(), initialSize, 
+					"log file should be larger after successful write")
+			}
+		})
+	}
+}
+
+func TestSetupServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  http.Handler
+		port     string
+		expected string
+	}{
+		{
+			name:     "default port",
+			handler:  http.NewServeMux(),
+			port:     "",
+			expected: ":8080",
+		},
+		{
+			name:     "custom port",
+			handler:  http.NewServeMux(),
+			port:     "9090",
+			expected: ":9090",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := setupServer(tt.handler, tt.port)
+			assert.Equal(t, tt.expected, server.Addr, "server address should match expected")
+			assert.NotNil(t, server.Handler, "server handler should not be nil")
+		})
+	}
+}
+
+func TestRunServer(t *testing.T) {
+	// Create a test server that we can control
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "should be able to create a test listener")
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+
+	// Start the server in a goroutine
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runServer(server)
+	}()
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Test that the server is running
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d", port))
+	require.NoError(t, err, "should be able to make request to server")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "server should respond with 200 OK")
+
+	// Shutdown the server
+	err = server.Shutdown(context.Background())
+	require.NoError(t, err, "should be able to shutdown server")
+
+	// Verify the server shutdown
+	select {
+	case err := <-errCh:
+		assert.Equal(t, http.ErrServerClosed, err, "should return server closed error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down within timeout")
 	}
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:stable-alpine
+
+# Copy built assets from build stage
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Copy nginx config
+COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/app/__tests__/page.test.tsx
+++ b/frontend/src/app/__tests__/page.test.tsx
@@ -1,30 +1,151 @@
 import React from "react";
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Home from '../page';
 
+// Mock the global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
 describe('Home page', () => {
+  // Helper to wait for the next tick
+test('renders without crashing', () => {
+  render(<Home />);
+});
+
+const waitForNextTick = () => new Promise(resolve => setTimeout(resolve, 0));
+
   beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({
+    mockFetch.mockClear();
+    // Default mock for health check
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ status: 'ok' })
-    }) as jest.Mock;
+    });
   });
 
-  test('shows connected status on successful fetch', async () => {
-    render(<Home />);
-    expect(screen.getByText('Drifter Frontend')).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByText(/connected/)).toBeInTheDocument());
+  describe('Health check', () => {
+    test('shows connected status on successful fetch', async () => {
+      render(<Home />);
+      expect(screen.getByText('Drifter Frontend')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText(/connected/)).toBeInTheDocument());
+    });
+
+    test('shows disconnected when fetch fails', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockRejectedValueOnce(new Error('fail'));
+      render(<Home />);
+      await waitFor(() => expect(screen.getByText('disconnected')).toBeInTheDocument());
+    });
+
+    test('shows error text when response is not ok', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce({ 
+        ok: false, 
+        statusText: 'Bad',
+        json: async () => ({ error: 'Bad request' })
+      });
+      render(<Home />);
+      await waitFor(() => expect(screen.getByText(/error: Bad/i)).toBeInTheDocument());
+    });
   });
 
-  test('shows disconnected when fetch fails', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('fail'));
-    render(<Home />);
-    await waitFor(() => expect(screen.getByText('disconnected')).toBeInTheDocument());
-  });
+  describe('Environment submission', () => {
+    const testEnv = {
+      metadata: {
+        name: 'Test Env',
+        version: '1.0.0',
+        author: 'Tester'
+      }
+    };
+    const testEnvString = JSON.stringify(testEnv, null, 2);
 
-  test('shows error text when response is not ok', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, statusText: 'Bad' });
-    render(<Home />);
-    await waitFor(() => expect(screen.getByText(/error:/i)).toBeInTheDocument());
+    test('allows typing in the textarea', async () => {
+      render(<Home />);
+      const textarea = screen.getByRole('textbox');
+      await userEvent.clear(textarea);
+      fireEvent.change(textarea, { target: { value: testEnvString } });
+      expect(textarea).toHaveValue(testEnvString);
+    });
+
+    test('submits environment successfully', async () => {
+      // Mock the form submission response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        statusText: 'OK'
+      });
+      
+      render(<Home />);
+      
+      // Wait for initial health check to complete
+      await waitFor(() => expect(screen.getByText(/connected/)).toBeInTheDocument());
+      
+      // Change the environment
+      const textarea = screen.getByRole('textbox');
+      fireEvent.change(textarea, { target: { value: testEnvString } });
+      
+      // Submit the form
+      const submitButton = screen.getByRole('button', { name: /submit environment/i });
+      await userEvent.click(submitButton);
+      
+      // Verify the fetch was called with the right parameters
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        expect.stringMatching(/\/environments$/),
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: testEnvString,
+        })
+      );
+      
+      // Verify success message
+      await waitFor(() => {
+        const statusElement = screen.getByText(/Status:/);
+        expect(statusElement).toHaveTextContent('submitted');
+      });
+    });
+
+    test('handles submission error', async () => {
+      const errorMessage = 'Invalid JSON';
+      // Mock the form submission error response
+      mockFetch.mockResolvedValueOnce({ 
+        ok: false, 
+        statusText: errorMessage
+      });
+      
+      render(<Home />);
+      
+      // Wait for initial health check to complete
+      await waitFor(() => expect(screen.getByText(/connected/)).toBeInTheDocument());
+      
+      const submitButton = screen.getByRole('button', { name: /submit environment/i });
+      await userEvent.click(submitButton);
+      
+      await waitFor(() => {
+        const statusElement = screen.getByText(/Status:/);
+        expect(statusElement).toHaveTextContent(`error: ${errorMessage}`);
+      });
+    });
+
+    test('handles network error on submission', async () => {
+      const errorMessage = 'Network error';
+      // Mock the network error on form submission
+      mockFetch.mockRejectedValueOnce(new Error(errorMessage));
+      
+      render(<Home />);
+      
+      // Wait for initial health check to complete
+      await waitFor(() => expect(screen.getByText(/connected/)).toBeInTheDocument());
+      
+      const submitButton = screen.getByRole('button', { name: /submit environment/i });
+      await userEvent.click(submitButton);
+      
+      await waitFor(() => {
+        const statusElement = screen.getByText(/Status:/);
+        expect(statusElement).toHaveTextContent('network error');
+      });
+    });
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,8 +2,20 @@
 
 import { useState, useEffect } from 'react';
 
+const DEFAULT_ENV = `{
+  "metadata": {
+    "name": "Test Environment Alpha",
+    "version": "0.1.0",
+    "author": "Solo7",
+    "created": "2025-06-21T12:00:00Z",
+    "tags": ["test", "prototype"]
+  }
+}`;
+
 export default function Home() {
   const [status, setStatus] = useState('checking...');
+  const [envText, setEnvText] = useState(DEFAULT_ENV);
+  const [submitStatus, setSubmitStatus] = useState('');
 
   useEffect(() => {
     const checkHealth = async () => {
@@ -26,12 +38,50 @@ export default function Home() {
     checkHealth();
   }, []);
 
+  const submitEnvironment = async () => {
+    const backendUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+    try {
+      const response = await fetch(`${backendUrl}/environments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: envText,
+      });
+      if (response.ok) {
+        setSubmitStatus('submitted');
+      } else {
+        setSubmitStatus(`error: ${response.statusText}`);
+      }
+    } catch (e) {
+      console.error('Failed to submit environment:', e);
+      setSubmitStatus('network error');
+    }
+  };
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+    <main className="flex min-h-screen flex-col items-center justify-start p-8 space-y-4">
       <h1 className="text-4xl font-bold">Drifter Frontend</h1>
-      <p className="mt-4">
-        Backend status: <span className="font-mono bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-1.5 rounded">{status}</span>
+      <p>
+        Backend status:{' '}
+        <span className="font-mono bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-1.5 rounded">
+          {status}
+        </span>
       </p>
+      <div className="w-full max-w-2xl">
+        <textarea
+          className="w-full h-64 p-2 border rounded text-sm dark:bg-gray-800"
+          value={envText}
+          onChange={(e) => setEnvText(e.target.value)}
+        />
+        <button
+          className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={submitEnvironment}
+        >
+          Submit Environment
+        </button>
+        {submitStatus && <p className="mt-2">Status: {submitStatus}</p>}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- allow the frontend to edit and POST environment JSON
- save posted environments on the backend
- make the log file path configurable
- add Go unit tests for health and environment endpoints

## Testing
- `npm run lint`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856df05ca8483299c213a587a2dbef7